### PR TITLE
Change default port to 4040

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-RV_BACKEND_URL=http://localhost:8080
+RV_BACKEND_URL=http://localhost:4040

--- a/rv-dev.desktop
+++ b/rv-dev.desktop
@@ -2,7 +2,7 @@
 Name=Ruokavälitys Development
 GenericName=RV
 Comment=TKO-äly Ruokavälitys
-Exec=env RV_BACKEND_URL=http://localhost:8080 kitty --hold --start-as fullscreen rv -u
+Exec=env RV_BACKEND_URL=http://localhost:4040 kitty --hold --start-as fullscreen rv -u
 Terminal=false
 Type=Application
 Categories=ConsoleOnly;System;

--- a/rv.desktop
+++ b/rv.desktop
@@ -2,7 +2,7 @@
 Name=Ruokavälitys
 GenericName=RV
 Comment=TKO-äly Ruokavälitys
-Exec=env RV_BACKEND_URL=http://localhost:8080 kitty --start-as fullscreen rv
+Exec=env RV_BACKEND_URL=http://localhost:4040 kitty --start-as fullscreen rv
 Terminal=false
 Type=Application
 Categories=ConsoleOnly;System;


### PR DESCRIPTION
In [tko-aly.localhost](https://github.com/TKOaly/tko-aly.localhost) port 8080 is used by traefik. Let's change the default port to 4040 so it doesn't clash with this in the local dev environment by default . RV could potentially be added to the localhost repo as well so this would be mandatory in that case.